### PR TITLE
Swap position of (t+b)/(t-b) in frustum matrix

### DIFF
--- a/mpl3d/glm.py
+++ b/mpl3d/glm.py
@@ -48,7 +48,7 @@ def frustum(left, right, bottom, top, znear, zfar):
     M[1, 1] = +2.0 * znear / (top - bottom)
     M[2, 2] = -(zfar + znear) / (zfar - znear)
     M[0, 2] = (right + left) / (right - left)
-    M[2, 1] = (top + bottom) / (top - bottom)
+    M[1, 2] = (top + bottom) / (top - bottom)
     M[2, 3] = -2.0 * znear * zfar / (zfar - znear)
     M[3, 2] = -1.0
     return M


### PR DESCRIPTION
Not completely sure, but it seems there is typo here, where `(top + bottom) / (top - bottom)` is at position M[2,1], but should be at M[1,2]. Checked it with the implementation of GLM (C++ version at https://github.com/g-truc/glm) and your own examples at https://www.labri.fr/perso/nrougier/python-opengl/

Does not matter much in this library though, because, when `top == - button` then the value is always zero, and since there are no direct calls to frustum, but instead `perspective` is used, that issue will probably not be noticed. However, the reason is why I wanted to make this PR is also to note that the same implementation of `frustum` is used at https://matplotlib.org/matplotblog/posts/custom-3d-engine/. If you agree with the fix, probably you would like to fix the article as well.

Having this chance once more, I would like to say again that appreciate your work a lot!

P.S.: Yes, I also checked the implementation of frustum with ChatGPT 😅
